### PR TITLE
Improve documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ Fork the repo, make your changes, then submit a pull request via [comparing fork
 ## Warning :
 
 Currently, we use `wiki.js` to manage our wiki.
-Please keep in mind some things won't work with yout favorite markdown editor, but will show properly on the wiki.
+Please keep in mind some things won't work with your favorite markdown editor, but will show properly on the wiki.
 
 For example,
 
@@ -15,7 +15,7 @@ For example,
 {.is-danger}
 ```
 
-Will probably not work on your markdown editor.
+This will probably not work in your markdown editor.
 
 Thanks in advance for the help you'll give us, and #KeepEvolving !
 
@@ -27,7 +27,7 @@ About assets : if you write for example
 ![image](/image.png)
 ```
 
-Then it'll consider that the image is located under Assets/image.png.
+Then it'll consider that the image is located under `Assets/image.png`.
 
 Please be sure to put the image in the right folder
 

--- a/home.md
+++ b/home.md
@@ -1,6 +1,5 @@
 ![evox_wiki.png](/evox_wiki.png)
 
-
 # Introduction
 
 **Welcome to [Evolution X Wiki](https://wiki.evolution-x.org)**
@@ -20,11 +19,11 @@ Let's get started!
 - **Akito Mizukito** (RealAkito) - Co-Founder, Project Manager
 - **Anierin Bliss** (AnierinB) - Co-Founder, Project Specialist
 
-### 📊 Technical informations
+### 📊 Technical information
 
-- Since 06/2024, **EvolutionX** is now based on LineageOS for more stability and performances gains.
+- Since 06/2024, **EvolutionX** is now based on [LineageOS](https://lineageos.org/) for more stability and performances gains.
 
-> Major version is currently `10` (VIC).
+> Major version is currently `10` (VIC/Android 15).
 {.is-success}
 
 # Evolution X Related Links

--- a/home.md
+++ b/home.md
@@ -1,4 +1,4 @@
-![evox_wiki.png](/evox_wiki.png)
+![Evolution X banner](/evox_wiki.png)
 
 # Introduction
 

--- a/installing-evolution-x.md
+++ b/installing-evolution-x.md
@@ -1,4 +1,5 @@
 # Installing Evolution X
+
 > This guide provides **basic** instructions for installing our ROM. **Always check** your device's [XDA thread](https://xdaforums.com) for specific exceptions.
 {.is-warning}
 
@@ -15,8 +16,8 @@ To get started, you will need to download the ROM for your device. It is importa
 > Do not flash builds for other devices, it will brick your device!
 {.is-danger}
 
-
 You can download the ROM zip from various sources.
+
 - [<img src="/favicons/sfav.png" alt="sitefav" style="width:20px; vertical-align:middle;"> EvolutionX's website](https://evolution-x.org/downloads)
 - [<img src="/favicons/sfav.svg" alt="sitefav" style="width:20px; vertical-align:middle;"> EvolutionX's SourceForge](https://sourceforge.net/projects/evolution-x/files/)
 - [<img src="/favicons/sfav.png" alt="sitefav" style="width:20px; vertical-align:middle;"> EvolutionX's Mirror](https://evolution-x.org/) (Currently under test)
@@ -27,14 +28,12 @@ To do so, you can visit our website and check if your device is available.
 > If you can't find your device, it doesn't mean that no one did it outside EvoX . It's called an "Unofficial build" and it may work. That said, we won't provide any support for it.
 {.is-info}
 
-
 ### Selecting the correct vendor ###
 
-> Note that Gapps are already included !
+> Note that Google apps and services (gapps) are already included !
 
 Check the XDA thread of your device to find the required vendor or firmware for the ROM and download it.
-The softwares needed will __always__ be highlighted on XDA.
-
+The softwares needed will **always** be highlighted on XDA.
 
 ### Flashing the ROM ###
 After having downloaded the correct ROM build and vendor/firmware zip file, we can proceed with the flashing process. Boot your device into recovery mode, and wipe data, cache and system using our recovery.
@@ -49,14 +48,13 @@ Flash the required vendor/firmware and the downloaded ROM build. Reboot to syste
 > Since our new website (available [here](https://evolution-x.org/downloads)), instructions are given for each device. Please check it if you want to know how to flash the rom for your device !
 {.is-success}
 
-
 ### Rooting your device ###
 
 There are many ways to root a device, and we won't provide support for it. That said, the more used methods are :
 
-- Magisk
+- [Magisk](https://github.com/topjohnwu/Magisk)
 - Apatch
-- Kernelsu
+- [Kernel SU](https://kernelsu.org/)
 
 > Each method can be supported, or may not be ! Always ask people having the same device as you.
 {.is-info}
@@ -69,7 +67,7 @@ Sometimes, **updates may break your system** so stay tuned when an update is out
 
 ### 1: OTA Updates
 
-EvolutionX has a built-in OTA update system. This means that when an update is out, it'll come directly in your settings with a notification, like if it was an "official" update (like if oneplus or xiaomi deployed one)
+EvolutionX has a built-in OTA update system. This means that when an update is out, it'll come directly in your settings with a notification, like if it was an "official" update (like if OnePlus or Xiaomi deployed one)
 
 To update via OTA, please follow the following tutorial.
 

--- a/lunch.md
+++ b/lunch.md
@@ -2,7 +2,7 @@
 > **FROM NOW ON, FOR ANDROID 15, YOU NEED TO DO `lunch lineage_$device-ap4a-$build_type`.**
 {.is-danger}
 
-Every time a release will change (E.g changing from ap3a to ap4a) I will update the wiki. If you find out it's not up-to-date, feel free to ping me on discord @onelots.
+Every time a release will change (E.g changing from `ap3a` to `ap4a`) I will update the wiki. If you find out it's not up-to-date, feel free to ping me on discord @onelots or [edit this page](https://github.com/Evolution-X/wiki/edit/main/lunch.md).
 
 > Since I will not update the whole wiki every time, I'll use `$release` instead of specifying the actual release.
 {.is-info}
@@ -13,7 +13,7 @@ Every time a release will change (E.g changing from ap3a to ap4a) I will update 
 
 So commands will be in the form `lunch lineage_$device-ap4a-$build_type`.
 
-# A quick lunch guide.
+# A quick lunch guide
 
 In this guide, we'll see how to use lunch, how it works and how to setup it properly.
 We'll see how to setup a device for building too.
@@ -28,6 +28,7 @@ When you make an unofficial build (community), you will have to find the sources
 This file well need to be named following your device's codename.
 **During this guide, when I'll talk about `device.xml`, replace `device` with your device's codename, of course...**
 In this file, we'll add all the trees we need. It usually depends on the device and the OEM, but you'll generally need :
+
 - The device tree(s)
 - The vendor tree(s)
 - Kernel sources
@@ -38,13 +39,13 @@ I say tree(s) because sometimes, a device shares commons trees with other device
 > During all this guide, we'll use Polaris (Xiaomi Mi Mix 2s) as an example.
 {.is-info}
 
-> Quick tip: if a device is supported by LineageOs, look into lineage.dependencies, usually everything is in it !
+> Quick tip: if a device is supported by LineageOS, look into lineage.dependencies, usually everything is in it !
 {.is-success}
 
 ---
 
 Once you found your trees, let's build our xml.
-Here is the classic strucure of a `.xml` (in this case, like I said, for Polaris.)
+Here is the classic structure of a `.xml` (in this case, like I said, for Polaris.)
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -69,7 +70,7 @@ Here is the classic strucure of a `.xml` (in this case, like I said, for Polaris
 </manifest>
 ```
 
-Let's explain what is in here.
+Let's explain what is in here:
 
 ```xml
 <!--Remotes-->
@@ -79,16 +80,17 @@ Let's explain what is in here.
 
 These lines tells the `repo sync` command where to look for when syncing dependencies. The remotes are the roots of where `repo sync` will have to look for.
 
-If we look closer at this line for example :
+If we look closer at this line for example:
+
 ```xml
 <project name="android_device_xiaomi_polaris"           path="device/xiaomi/polaris"       remote="los" />
 ```
 
-We tell the `repo sync` command to clone https://github.com/lineageos/android_device_xiaomi_polaris under the `device/xiaomi/polaris` folder.
+We tell the `repo sync` command to clone https://github.com/lineageos/android_device_xiaomi_polaris into the `device/xiaomi/polaris` folder.
 
 ---
 
-> `device.xml` will need to be located under .repo/local_manifests/device.xml
+> `<device>.xml` will need to be located under `.repo/local_manifests/<device>.xml`
 {.is-warning}
 
 When your device.xml is written, and in the right directory, simply sync the sources:
@@ -97,14 +99,16 @@ When your device.xml is written, and in the right directory, simply sync the sou
 repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags
 ```
 
-And everything will be retrieved. Then you only need to
+And everything will be retrieved. Then you only need to:
 
 ```bash
 lunch lineage_$device-$release-$build_type
 ```
-(Where `$device` is your device's codename and `$build_type` is the build type. There is a paragraph about it at the end of this guide, we'll come back to it later.)
+
+Where `$device` is your device's codename and `$build_type` is the build type. There is a paragraph about it at the end of this guide, we'll come back to it later.
 
 But for Polaris, it would look like
+
 ```bash
 lunch lineage_polaris-$release-userdebug
 ```
@@ -122,7 +126,7 @@ Now that you have been granted access to your device's trees, you can setup the 
 > When you are an official maintainer, you don't need device.xml anymore since everything will be synced automatically when lunch command is called.
 {.is-info}
 
-EvolutionX uses the same system as LineageOs for syncing dependencies automatically without having to rewrite the device.xml every time.
+EvolutionX uses the same system as LineageOS for syncing dependencies automatically without having to rewrite the device.xml every time.
 
 When you become a maintainer, remove the `lineage.dependencies` file and replace it with an `evolution.dependencies` instead in your tree.
 
@@ -143,14 +147,14 @@ Here is the evolution.dependencies for Polaris:
 
 As you can see, we find only 2 trees instead of 6 in the `polaris.xml`
 But as you can see too, there is a `device_xiaomi_sdm845-common` repository.
-Looking at the `evolution.dependencies` in this repo, we see that it contains all the trees needed for the devices using the same common tree, so no need to set it up __again__
+Looking at the `evolution.dependencies` in this repo, we see that it contains all the trees needed for the devices using the same common tree, so no need to set it up **again**
 
 > In this situation, don't add the trees again ! it will generate a conflict.
 {.is-danger}
 
 Of course, it may depend. Always check the `lineage.dependencies`, it will contains all you need.
 
-You can of course setup external repos. exemple with polaris with Xiaomi cam added to it:
+You can of course setup external repos. Example with polaris with Xiaomi camera added to it:
 
 ```json
 [
@@ -185,7 +189,6 @@ lunch lineage_$device-$release-$build_type
 
 This command will clone everything for you directly !
 
-
 > This is explained [here](/onboarding) too.
 {.is-success}
 
@@ -202,18 +205,20 @@ Actually, a few more args are available.
 | `userdebug`| Similar to `user` but with additional debugging tools enabled. Used for testing and debugging on near-final builds. Can be used for releases as well. |
 | `eng`      | Includes all development tools and debugging options. Used by developers during active development and testing.       |
 
-
 The different commands would be :
 
 ```bash
 lunch lineage_polaris-$release-user
 ```
+
 or
 
 ```bash
 lunch lineage_polaris-$release-userdebug
 ```
+
 or
+
 ```bash
 lunch lineage_polaris-$release-eng
 ```
@@ -221,8 +226,7 @@ lunch lineage_polaris-$release-eng
 > eng build is **NOT** intended for release.
 {.is-danger}
 
-
-When it's done,
+When it's done:
 
 ```bash
 m evolution

--- a/reporting-a-bug.md
+++ b/reporting-a-bug.md
@@ -1,4 +1,5 @@
 # Reporting a bug
+
 Aaaaah, bugs. Yes, it is annoying. But how to fight against it ?
 
 > Disclaimer: 99% of the time, **we are aware of the bugs.**
@@ -20,7 +21,7 @@ Here is a list of things you can do before rushing to talk with your maintainer 
 
 ## I've done what is said above, but no one reported it yet...
 
-Okay, maybe your bug is unknow. You should report it to your maintainer obviously, but there is a way to do so !
+Okay, maybe your bug is unknown. You should report it to your maintainer obviously, but there is a way to do so !
 
 > Maintainers need real **bugs report**, not just **complaints**.
 {.is-success}
@@ -38,21 +39,23 @@ If you want to please your maintainer, here is how you should make a bug report.
 
 **How can I take a logcat?**
 
-You can use ADB to record a logcat by using the command
+You can use ADB to record a logcat by using the command:
+
 ```bash
 adb logcat -d
 ```
 
-Alternatively you can use the [syslog](https://play.google.com/store/apps/details?id=com.tortel.syslog&hl=en_US) app.
+Alternatively you can use the [syslog](https://play.google.com/store/apps/details?id=com.tortel.syslog&hl=en_US) or [LogFox](https://github.com/F0x1d/LogFox).
 
 ## Example bug report format
 
 Bug description: `<write the description of the bug here>`
 How to reproduce: `<write the method of reproducing the bug here>`
-Logcat: `<upload your logcat to our `[paste server](https://paste.evolution-x.org) `and paste the link here>`
+Logcat: `<upload your logcat to our`[paste server](https://paste.evolution-x.org) `and paste the link here>`
 Screenshots: `<you can attach screenshots to the bug report>`
 
 ## Why do I need to keep the bug reporting rules?
+
 It is **way easier** for the developer and for other users as well, to see your bug report organized and not just a complaint.
 This way the developer will be able to implement a solution to the bug you found and other users won't re-report the bug.
 

--- a/setting-up-env.md
+++ b/setting-up-env.md
@@ -1,6 +1,6 @@
 # Setting up Environments to build Evolution X
 
-This guide is for __Linux Users__ targetting Ubuntu 22.04 LTS users.
+This guide is for __Linux Users__ targeting Ubuntu 22.04 LTS users.
 
 > Make sure you have the appropriate performance requirements to build Android !
 Minimum requirements for A14 are : 12 cores, 64Gb of RAM and 64 bit system.

--- a/setting-up-env.md
+++ b/setting-up-env.md
@@ -1,10 +1,13 @@
 # Setting up Environments to build Evolution X
 
-This guide is for __Linux Users__ targetting Ubuntu 22.04 LTS users. This guide does not tend to work with WSL (both V1 and V2), please use real "Linux Environment", use a "Virtual Machine" or get yourself a server!
+This guide is for __Linux Users__ targetting Ubuntu 22.04 LTS users.
 
 > Make sure you have the appropriate performance requirements to build Android !
 Minimum requirements for A14 are : 12 cores, 64Gb of RAM and 64 bit system.
 {.is-warning}
+
+> This guide has been tested to work on WSL 2 Ubuntu 24.04.1 LTS
+{.is-info}
 
 
 **Don't wanna go thru hassles? Introduce [akhilnarang's script](https://github.com/akhilnarang/scripts) repository.**
@@ -31,12 +34,12 @@ after you've done these commands you can skip to [Step 3](#h-3-make-a-folder-and
 A 64-bit version of Ubuntu (22.04 is recommended as of now because of LTS).
 
 ```bash
-sudo apt-get update && sudo apt-get install git git-lfs gnupg flex bison gperf libsdl1.2-dev libesd0-dev squashfs-tools build-essential zip curl ccache libncurses5-dev zlib1g-dev openjdk-11-jre openjdk-11-jdk pngcrush schedtool libxml2 libxml2-utils xsltproc lzop libc6-dev schedtool g++-multilib lib32z1-dev lib32ncurses5-dev gcc-multilib maven tmux screen w3m ncftp rsync
-````
+sudo apt-get update && sudo apt-get install git git-lfs gnupg flex bison gperf libsdl1.2-dev libesd0-dev squashfs-tools build-essential zip curl ccache libncurses5-dev zlib1g-dev openjdk-11-jre openjdk-11-jdk pngcrush schedtool libxml2 libxml2-utils xsltproc lzop libc6-dev schedtool g++-multilib lib32z1-dev lib32ncurses5-dev gcc-multilib maven tmux screen w3m ncftp rsync libssl-dev
+```
 
-(If you face a problem while installing libesd0-dev  package, follow the steps from [here](https://askubuntu.com/questions/1082722/unable-to-locate-package-libesd0-dev-on-ubuntu-18-04#)
+If you face a problem while installing libesd0-dev package, follow the steps from [this Stack Overflow post](https://askubuntu.com/questions/1082722/unable-to-locate-package-libesd0-dev-on-ubuntu-18-04#)
 
-You can install those packages instead : `libncurses5 curl python-is-python3`
+You can install those packages instead: `libncurses5 curl python-is-python3`
 
 ## 3: Make A Folder And Initialize Repo ##
 
@@ -58,8 +61,23 @@ repo sync -c -j$(nproc --all) --force-sync --no-clone-bundle --no-tags
 {.is-info}
 
 
-## 4: The Keys. ##
+## 4: Source the Build Environment
 
+Run this command to load the necessary tools required for building.
+
+```bash
+. build/envsetup.sh
+```
+
+> You can add this in your `.bashrc` to automatically run it:
+>
+> ```bash
+> echo 'cd evo && source build/envsetup.sh && cd' >> ~/.bashrc
+> ```
+>
+{.is-info}
+
+## 5: The Keys. ##
 
 > Without this, your build won't be able to pass DEVICE or BASIC integrity.
 Remember to **BACKUP** your keys !
@@ -67,8 +85,8 @@ Remember to **BACKUP** your keys !
 
 ### First case: Unofficial Build: ###
 
-If you are an unofficial builder, There is a [script](https://github.com/Evolution-X/vendor_evolution-priv_keys-template) for you that will generate the keys.
-Simply execute
+If you are an unofficial builder, there is a [script](https://github.com/Evolution-X/vendor_evolution-priv_keys-template) that will generate the keys for you. Simply execute:
+
 ```bash
 croot && git clone https://github.com/Evolution-X/vendor_evolution-priv_keys-template vendor/evolution-priv/keys
 cd vendor/evolution-priv/keys
@@ -78,17 +96,18 @@ cd vendor/evolution-priv/keys
 ./keys.sh
 ```
 
-
 #### Second case: Official Build: ###
+
 This will need you to be logged in git on your server.
+
 ```bash
 croot && git clone https://github.com/Evolution-X/vendor_evolution-priv_keys vendor/evolution-priv/keys
 ```
+
 > If any of you leak this, whether that be intentionally, or on accident, you will be removed from the project and never allowed back. So, if you use a shared server, be careful, otherwise it could very well mean the end of your time at Evolution X
 {.is-warning}
 
-
-## 5: Building ##
+## 6: Building ##
 
 ### A: Note for official maintainers
 > Skip this part if you are not an official maintainer.
@@ -113,9 +132,6 @@ Then keep reading this.
 ### B: For official and unofficial maintainers
 
 ---
-```bash
-. build/envsetup.sh
-```
 
 ```bash
 lunch lineage_$device-$release-userdebug


### PR DESCRIPTION
- Fix multiple violations of [Markdown Lint](https://github.com/markdownlint/markdownlint)
- Include that it works with WSL 2 Ubuntu 24.04.1 LTS
- Add missing packages like `libssl-dev`
- Multiple other improvements

<details>
<summary>Commits</summary>

- **docs: update image alt text in home.md** ([commit](https://github.com/Turtlepaw/wiki/commit/14668718a7ae3872fcf20e2926dfdd658e6e3409))
- **docs: fix violations of markdown lint and errors in home and installing guides** ([commit](https://github.com/Turtlepaw/wiki/commit/4cb3e39ce03d0b65e69a1f5573c313ac85558f3d))
- **docs: improve clarity and fix issues in lunch and reporting-a-bug guides** ([commit](https://github.com/Turtlepaw/wiki/commit/e397b9387d087a16262a454ef196160fcb4c4f7b))
- **docs: update environment setup guide for WSL 2 compatibility and clarify installation steps** ([commit](https://github.com/Turtlepaw/wiki/commit/cfa1f8c933ed64c726f5d99804cfc4add071b4d3))
- **fix: error in readme** ([commit](https://github.com/Turtlepaw/wiki/commit/b00517f8bff42370db5e366231287d6ffe071fdb))
</details>
